### PR TITLE
Fix missing helper methods in LLMService

### DIFF
--- a/codecrackr/services/llm_service.py
+++ b/codecrackr/services/llm_service.py
@@ -310,3 +310,20 @@ Make it comprehensive but accessible to developers at different skill levels."""
     def count_tokens(self, text: str) -> int:
         """Count tokens in text (rough estimate)"""
         return len(text.split()) * 1.3
+
+    # Added convenience wrappers used by TutorialGenerator
+    def generate_project_summary(self, repo_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate a summary of the repository using existing summary call"""
+        # TutorialGenerator previously expected this method.  We simply forward
+        # to ``generate_repository_summary`` without any file analyses.
+        return self.generate_repository_summary(repo_data, [])
+
+    def generate_architecture_overview(self, repo_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate architecture overview data.
+
+        Currently ``LLMService`` only creates a Mermaid diagram string.  To keep
+        compatibility with callers expecting a dictionary, we wrap the diagram
+        in a dictionary under the ``architecture`` key.
+        """
+        diagram = self.generate_architecture_diagram(repo_data)
+        return {"architecture": diagram}

--- a/codecrackr/services/llm_service_simple.py
+++ b/codecrackr/services/llm_service_simple.py
@@ -310,3 +310,13 @@ Make it comprehensive but accessible to developers at different skill levels."""
     def count_tokens(self, text: str) -> int:
         """Count tokens in text (rough estimate)"""
         return len(text.split()) * 1.3
+
+    # Compatibility helpers for TutorialGenerator
+    def generate_project_summary(self, repo_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return repository summary using existing method."""
+        return self.generate_repository_summary(repo_data, [])
+
+    def generate_architecture_overview(self, repo_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return architecture overview in a dictionary form."""
+        diagram = self.generate_architecture_diagram(repo_data)
+        return {"architecture": diagram}


### PR DESCRIPTION
## Summary
- implement `generate_project_summary` and `generate_architecture_overview` in `LLMService`
- add equivalent helpers in `LLMServiceSimple`

## Testing
- `python - <<'EOF'
from test_setup import test_imports, test_config, test_github_utils
print('imports:', test_imports())
print('config:', test_config())
print('github utils:', test_github_utils())
EOF`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_687e0b2ab27483299e478894c6dd8b7b