### PR TITLE
Document new API key env vars

### DIFF
--- a/codecrackr/.env.example
+++ b/codecrackr/.env.example
@@ -4,6 +4,11 @@ OPENAI_API_KEY=your_openai_api_key_here
 # OpenRouter API Configuration (Alternative)
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
+# Other LLM providers (optional)
+GEMINI_API_KEY=your_gemini_api_key_here
+CLAUDE_API_KEY=your_claude_api_key_here
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+
 # GitHub API Configuration (Optional - for higher rate limits)
 GITHUB_TOKEN=your_github_token_here
 

--- a/codecrackr/README.md
+++ b/codecrackr/README.md
@@ -60,6 +60,11 @@ OPENAI_API_KEY=your_openai_api_key_here
 # OR
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
+# Optional: Keys for other LLM providers
+GEMINI_API_KEY=your_gemini_api_key_here
+CLAUDE_API_KEY=your_claude_api_key_here
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+
 # Optional: For higher GitHub API limits
 GITHUB_TOKEN=your_github_token_here
 

--- a/codecrackr/config.py
+++ b/codecrackr/config.py
@@ -13,6 +13,9 @@ class Config:
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
     OPENROUTER_API_KEY = os.getenv('OPENROUTER_API_KEY')
     GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
+    GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
+    CLAUDE_API_KEY = os.getenv('CLAUDE_API_KEY')
+    DEEPSEEK_API_KEY = os.getenv('DEEPSEEK_API_KEY')
     
     # Application Settings
     MAX_REPO_SIZE_MB = int(os.getenv('MAX_REPO_SIZE_MB', '100'))


### PR DESCRIPTION
## Summary
- allow configuring Gemini, Claude and DeepSeek API keys
- document these optional env vars in the setup guide
- update `.env.example` with the same keys

## Testing
- `python - <<'PY'
import test_setup

test_setup.main()
PY` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_687e129db67083299ea00096d8b69ecc