### PR TITLE
Add admin dashboard blueprint

### DIFF
--- a/codecrackr/admin/__init__.py
+++ b/codecrackr/admin/__init__.py
@@ -1,0 +1,59 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session
+from functools import wraps
+import os
+
+from config import Config
+from services.ai_manager import AIManager
+
+admin_bp = Blueprint('admin', __name__, template_folder='../templates/admin')
+
+
+def login_required(view_func):
+    """Decorator to require login for admin routes."""
+    @wraps(view_func)
+    def wrapped(*args, **kwargs):
+        if not session.get('admin_authenticated'):
+            return redirect(url_for('admin.login'))
+        return view_func(*args, **kwargs)
+    return wrapped
+
+
+@admin_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    """Admin login page"""
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username', '')
+        password = request.form.get('password', '')
+        config = Config()
+        if username == config.ADMIN_USERNAME and password == config.ADMIN_PASSWORD:
+            session['admin_authenticated'] = True
+            return redirect(url_for('admin.dashboard'))
+        error = 'Invalid credentials'
+    return render_template('admin/login.html', error=error)
+
+
+@admin_bp.route('/dashboard', methods=['GET', 'POST'])
+@login_required
+def dashboard():
+    """Admin dashboard with provider management"""
+    if request.method == 'POST':
+        # Update API keys
+        for provider in ['openai', 'gemini', 'openrouter']:
+            key = request.form.get(f'{provider}_key')
+            if key is not None:
+                os.environ[f'{provider.upper()}_API_KEY'] = key.strip()
+        # Store active provider in session
+        active = request.form.get('active_provider')
+        if active:
+            session['active_provider'] = active
+        else:
+            session.pop('active_provider', None)
+
+    ai_manager = AIManager()
+    providers = ai_manager.get_provider_status()
+    active_provider = session.get('active_provider', '')
+    return render_template('admin/dashboard.html',
+                           providers=providers,
+                           active_provider=active_provider)
+

--- a/codecrackr/app.py
+++ b/codecrackr/app.py
@@ -13,10 +13,12 @@ from services.llm_service import LLMService
 from services.tutorial_generator import TutorialGenerator
 from utils.cleanup import cleanup_temp_files
 from utils.github_utils import validate_github_url
+from admin import admin_bp
 
 app = Flask(__name__)
 app.config.from_object(Config)
 CORS(app)
+app.register_blueprint(admin_bp, url_prefix='/admin')
 
 # Initialize services
 repo_analyzer = RepoAnalyzer()

--- a/codecrackr/config.py
+++ b/codecrackr/config.py
@@ -8,9 +8,14 @@ class Config:
     SECRET_KEY = os.getenv('SECRET_KEY', 'dev-secret-key-change-in-production')
     FLASK_ENV = os.getenv('FLASK_ENV', 'development')
     DEBUG = os.getenv('FLASK_DEBUG', 'True').lower() == 'true'
+
+    # Admin credentials
+    ADMIN_USERNAME = os.getenv('ADMIN_USERNAME', 'admin')
+    ADMIN_PASSWORD = os.getenv('ADMIN_PASSWORD', 'password')
     
     # API Keys
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+    GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')
     OPENROUTER_API_KEY = os.getenv('OPENROUTER_API_KEY')
     GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
     

--- a/codecrackr/templates/admin/dashboard.html
+++ b/codecrackr/templates/admin/dashboard.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Dashboard - CodeCrackr{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto py-12 px-4">
+    <h1 class="text-2xl font-bold mb-6">AI Provider Management</h1>
+    <form method="post" class="space-y-6">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead>
+                <tr>
+                    <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Provider</th>
+                    <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">Enabled</th>
+                    <th class="px-4 py-2 text-left text-sm font-semibold text-gray-700">API Key</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                {% for name, info in providers.items() %}
+                <tr>
+                    <td class="px-4 py-2">{{ info.name }}</td>
+                    <td class="px-4 py-2">{{ 'Yes' if info.enabled else 'No' }}</td>
+                    <td class="px-4 py-2">
+                        <input type="text" name="{{ name }}_key" value="{{ info.api_key or '' }}" class="w-full border rounded px-2 py-1" placeholder="Enter API key">
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <div>
+            <label class="block text-sm font-medium mb-1" for="active_provider">Active Provider</label>
+            <select name="active_provider" id="active_provider" class="w-full border rounded px-3 py-2">
+                <option value="" {% if not active_provider %}selected{% endif %}>Auto</option>
+                {% for name in providers.keys() %}
+                <option value="{{ name }}" {% if active_provider==name %}selected{% endif %}>{{ name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Save</button>
+    </form>
+</div>
+{% endblock %}
+

--- a/codecrackr/templates/admin/login.html
+++ b/codecrackr/templates/admin/login.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Login - CodeCrackr{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto py-12 px-4">
+    <h1 class="text-2xl font-bold mb-4">Admin Login</h1>
+    {% if error %}
+    <p class="text-red-600 mb-4">{{ error }}</p>
+    {% endif %}
+    <form method="post" class="space-y-4">
+        <div>
+            <label class="block text-sm font-medium mb-1" for="username">Username</label>
+            <input type="text" name="username" id="username" class="w-full border rounded px-3 py-2">
+        </div>
+        <div>
+            <label class="block text-sm font-medium mb-1" for="password">Password</label>
+            <input type="password" name="password" id="password" class="w-full border rounded px-3 py-2">
+        </div>
+        <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded">Login</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `admin` blueprint with login and dashboard
- list AI provider status and allow updating keys
- register the blueprint in the main app
- extend Config with admin credentials and Gemini key
- add templates for admin login and dashboard

## Testing
- `python -m py_compile codecrackr/admin/__init__.py`
- `python - <<'PY'
import admin
PY` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_687e129f507c8329b96e6b1fb95fc00c